### PR TITLE
printf() replaced with PRINTF()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,20 @@ BIN_UTILS := $(BIN)/utils
 INCLUDES  := $(SRC)/include
 DOC       := doc
 
+# Build options
+ENABLE_DEBUG ?= true
+
 # Compiler options
 GCC           =  gcc
 CC            =  $(GCC)
 CFLAGS        := $(CFLAGS) -Wall -g
+DFLAGS        := 
 OUTPUT_OPTION =  -o $@
+
+ifeq ($(ENABLE_DEBUG),true)
+ DFLAGS += -DENABLE_DEBUG 
+endif
+
 ################################################################################
 
 ## Functions ###################################################################
@@ -50,7 +59,7 @@ endef
 define gen-lib-rule
  $(call transform-csource,$1,$(BIN_LIB)/,.o): $1 $(subst .c,.h,$1)
 	$$(call make-depend,$$<, $$@, $$(subst .o,.d,$$@))
-	$(COMPILE.c) $$< $(includes) $(CFLAGS) -o $$@
+	$(COMPILE.c) $$< $(includes) $(CFLAGS) $(DFLAGS) -o $$@
 endef
 
 # Generate a single library compilation rule.
@@ -58,7 +67,7 @@ endef
 define gen-testlib-rule
  $(call transform-csource,$1,$(BIN_TESTS)/,.o): $1
 	$$(call make-depend,$$<, $$@, $$(subst .o,.d,$$@))
-	$(COMPILE.c) $$< $(includes) $(CFLAGS) -o $$@
+	$(COMPILE.c) $$< $(includes) $(CFLAGS) $(DFLAGS) -o $$@
 endef
 
 # $(call transform-csource,$(subst run_,,$1),$(BIN_TEST)/,): $1
@@ -67,7 +76,7 @@ endef
 define gen-test-rule
  $(call transform-csource,$1,$(BIN_TESTS)/,): $1
 	$$(call make-depend,$$<, $$@, $$(addsuffix .d,$$@))
-	$(CC) $(includes) $(CFLAGS) -o $$@ $$< $(libs) $(testlibs)
+	$(CC) $(includes) $(CFLAGS) $(DFLAGS) -o $$@ $$< $(libs) $(testlibs)
 endef
 
 # Generate a single library compilation rule.
@@ -75,7 +84,7 @@ endef
 define gen-util-rule
  $(call transform-csource,$1,$(BIN_UTILS)/,): $1
 	$$(call make-depend,$$<, $$@, $$(addsuffix .d,$$@))
-	$(CC) $(includes) $(CFLAGS) -o $$@ $$< $(libs)
+	$(CC) $(includes) $(CFLAGS) $(DFLAGS) -o $$@ $$< $(libs)
 endef
 
 # If this doesn't work, an ugly SED-based solution is required.
@@ -87,6 +96,7 @@ $(GCC)	-MM                     \
         -MT $2                  \
         $(includes)             \
         $(CFLAGS)               \
+        $(DFLAGS)               \
         $(CPPFLAGS)             \
         $(TARGET_ARCH)          \
         $1

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ BIN       := bin
 BIN_LIB   := $(BIN)/lib
 BIN_TESTS := $(BIN)/tests
 BIN_UTILS := $(BIN)/utils
+INCLUDES  := $(SRC)/include
 DOC       := doc
 
 # Compiler options
@@ -49,7 +50,7 @@ endef
 define gen-lib-rule
  $(call transform-csource,$1,$(BIN_LIB)/,.o): $1 $(subst .c,.h,$1)
 	$$(call make-depend,$$<, $$@, $$(subst .o,.d,$$@))
-	$(COMPILE.c) $$< $(CFLAGS) -o $$@
+	$(COMPILE.c) $$< $(includes) $(CFLAGS) -o $$@
 endef
 
 # Generate a single library compilation rule.
@@ -57,7 +58,7 @@ endef
 define gen-testlib-rule
  $(call transform-csource,$1,$(BIN_TESTS)/,.o): $1
 	$$(call make-depend,$$<, $$@, $$(subst .o,.d,$$@))
-	$(COMPILE.c) $$< $(CFLAGS) -o $$@
+	$(COMPILE.c) $$< $(includes) $(CFLAGS) -o $$@
 endef
 
 # $(call transform-csource,$(subst run_,,$1),$(BIN_TEST)/,): $1
@@ -66,7 +67,7 @@ endef
 define gen-test-rule
  $(call transform-csource,$1,$(BIN_TESTS)/,): $1
 	$$(call make-depend,$$<, $$@, $$(addsuffix .d,$$@))
-	$(CC) $(CFLAGS) -o $$@ $$< $(libs) $(testlibs)
+	$(CC) $(includes) $(CFLAGS) -o $$@ $$< $(libs) $(testlibs)
 endef
 
 # Generate a single library compilation rule.
@@ -74,7 +75,7 @@ endef
 define gen-util-rule
  $(call transform-csource,$1,$(BIN_UTILS)/,): $1
 	$$(call make-depend,$$<, $$@, $$(addsuffix .d,$$@))
-	$(CC) $(CFLAGS) -o $$@ $$< $(libs)
+	$(CC) $(includes) $(CFLAGS) -o $$@ $$< $(libs)
 endef
 
 # If this doesn't work, an ugly SED-based solution is required.
@@ -84,6 +85,7 @@ $(GCC)	-MM                     \
         -MF $3                  \
         -MP                     \
         -MT $2                  \
+        $(includes)             \
         $(CFLAGS)               \
         $(CPPFLAGS)             \
         $(TARGET_ARCH)          \
@@ -122,6 +124,9 @@ libsources :=  $(SRC)/dbobjects/relation.c \
                $(SRC)/dbparser/dbcreate.c \
                $(SRC)/dbparser/dbinsert.c \
                $(SRC)/dbparser/dbparser.c
+
+# Generate a list of include directories
+includes := $(addprefix -I,$(INCLUDES))
 
 # Generate list of libraries to compile.
 libs        := $(addprefix $(BIN_LIB)/,$(subst .c,.o,$(notdir $(libsources))))

--- a/src/dboutput/query_output.c
+++ b/src/dboutput/query_output.c
@@ -22,6 +22,7 @@
 /******************************************************************************/
 
 #include "query_output.h"
+#include "debug.h"
 
 #if 0
 void* calloc(int num, int size)
@@ -86,7 +87,7 @@ db_int sizeQuery(db_op_base_t *op, db_tuple_t *next_t, db_query_mm_t *mmp)
 void printQuery(db_op_base_t *op, db_query_mm_t *mmp)
 {
 	char *output = formatQuery(op, mmp);
-	printf("%s\n", output);
+	PRINTF("%s\n", output);
 	free(output);
 }
 
@@ -159,7 +160,7 @@ char* formatQuery(db_op_base_t *op, db_query_mm_t *mmp)
 
 void printTuple(db_tuple_t *toprint, db_op_base_t *op, db_int *widths)
 {
-	printf("%s\n", formatTuple(toprint, op, widths));
+	PRINTF("%s\n", formatTuple(toprint, op, widths));
 }
 
 char* formatTuple(db_tuple_t *toprint, db_op_base_t *op, db_int *widths)
@@ -199,7 +200,7 @@ char* formatTuple(db_tuple_t *toprint, db_op_base_t *op, db_int *widths)
 /* Print a formatted row separator. */
 void printRowSeparator(db_op_base_t *op, db_int *widths)
 {
-	printf("%s\n", formatRowSeparator(op, widths));
+	PRINTF("%s\n", formatRowSeparator(op, widths));
 }
 
 /* Make a row separator. */

--- a/src/dbparser/dblexer.c
+++ b/src/dbparser/dblexer.c
@@ -22,6 +22,7 @@
 /******************************************************************************/
 
 #include "dblexer.h"
+#include "debug.h"
 
 /*** Macros for Lexer modes ***/
 /**
@@ -245,7 +246,7 @@ void printtoken(db_lexer_token_t *tokenp, db_lexer_t *lexerp)
 	db_int i = tokenp->start;
 	while (i < tokenp->end && lexerp->command[i] != '\0')
 	{
-		printf("%c", lexerp->command[i]);
+		PRINTF("%c", lexerp->command[i]);
 		fflush(stdout);
 		++i;
 	}

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -1,0 +1,47 @@
+//*****************************************************************************
+/**
+@file		debug.h
+@author		Andrii Kuplevakhskyi
+@brief		Debug utlities (printf() etc.). The utilities can be
+                enabled or disabled
+
+@details
+@copyright	Copyright 2016 Andrii Kuplevakhskyi
+@license	Licensed under the Apache License, Version 2.0 (the "License");
+		you may not use this file except in compliance with the License.
+		You may obtain a copy of the License at
+			http://www.apache.org/licenses/LICENSE-2.0
+@par
+		Unless required by applicable law or agreed to in writing,
+		software distributed under the License is distributed on an
+		"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+		either express or implied. See the License for the specific
+		language governing permissions and limitations under the
+		License.
+*/
+//*****************************************************************************
+
+#include <stdio.h>
+
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#ifdef ENABLE_DEBUG
+ #define DEBUG_ENABLED (1)
+#else // ENABLE_DEBUG
+ #define DEBUG_ENABLED (0)
+#endif //ENABLE_DEBUG
+
+
+#define PRINTF(...) \
+    do \
+    { \
+        if (0 != DEBUG_ENABLED) \
+        { \
+            printf(__VA_ARGS__); \
+        } \
+    } while (1 == 0)
+
+
+#endif // DEBUG_H
+

--- a/src/utils/cfs_init_test_relations.c
+++ b/src/utils/cfs_init_test_relations.c
@@ -22,6 +22,7 @@
 //*****************************************************************************
 
 #include "cfs_init_test_relations.h"
+#include "debug.h"
 
 db_int integerlength(db_int value)
 {
@@ -151,7 +152,7 @@ db_int init_cfs_test_relations(char *relationname, db_int numattr,
 	cfs_fd = cfs_open(relationname, CFS_WRITE);
 	if (0 > cfs_fd)
 	{
-		printf("Could not open file for writing.\n");
+		PRINTF("Could not open file for writing.\n");
 		return -1;
 	}
 	

--- a/src/utils/gen_bench_relations.c
+++ b/src/utils/gen_bench_relations.c
@@ -23,6 +23,7 @@
 /*****************************************************************************/
 
 #include "gen_bench_relations.h"
+#include "debug.h"
 
 db_int integerlength(db_int value)
 {
@@ -63,7 +64,7 @@ db_int gen_bench_relation(char *relationname, db_int numattr,
 	myfile = db_openwritefile(relationname);
 	if (0 > myfile)
 	{
-		printf("Could not open file for writing.\n");
+		PRINTF("Could not open file for writing.\n");
 		return -1;
 	}
 	


### PR DESCRIPTION
- Created a file (+directory) `include/debug.h` containing the `PRINTF` macro that's defined based on `ENABLE_DEBUG`;
- In Makefile created the variable `INCLUDES` based on which a set of options `-I<include_dir>` for GCC is generated;
- In Makefile `ENABLE_DEBUG` is checked and based on its value a decision is made whether to add the flag `-DENABLE_DEBUG`;
- `printf()` replaced with `PRINTF()` in a number of sources excluding unit tests.
